### PR TITLE
Stop using deprecated increment/decrement operators

### DIFF
--- a/Sources/SHA1.swift
+++ b/Sources/SHA1.swift
@@ -85,8 +85,8 @@ internal class SHA1 {
 		var counter = 0
 
 		while msgLength % len != (len - 8) {
-			counter++
-			msgLength++
+			counter += 1
+			msgLength += 1
 		}
 
 		tmpMessage += Array<UInt8>(count: counter, repeatedValue: 0)

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -224,7 +224,8 @@ public class WebSocket {
 				guard let maskKey = frame.maskKey else { return -1 }
 				_data = []
 				for byte in data[0..<Int(consumeLength)] {
-					_data.append(byte ^ maskKey[self.frames.unsafeLast.maskOffset++ % 4])
+					_data.append(byte ^ maskKey[self.frames.unsafeLast.maskOffset % 4])
+					self.frames.unsafeLast.maskOffset += 1
 				}
 			} else {
 				_data = data


### PR DESCRIPTION
Recent Swift compiler snapshots emit deprecation warnings for this.
