### PR TITLE
Timeout should be parameter

### DIFF
--- a/Sources/WebSocket/WebSocket.swift
+++ b/Sources/WebSocket/WebSocket.swift
@@ -52,12 +52,12 @@ public final class WebSocket {
     fileprivate let pongEventEmitter = EventEmitter<Buffer>()
     fileprivate let closeEventEmitter = EventEmitter<(code: CloseCode?, reason: String?)>()
     
-    fileprivate let timeout: Double
+    fileprivate let connectionTimeout: Double
 
-    public init(stream: Axis.Stream, mode: Mode, timeout: Double = 60.seconds) {
+    public init(stream: Axis.Stream, mode: Mode, connectionTimeout: Double = 60.seconds) {
         self.stream = stream
         self.mode = mode
-        self.timeout = timeout
+        self.connectionTimeout = connectionTimeout
     }
 
     @discardableResult
@@ -142,7 +142,7 @@ public final class WebSocket {
     public func start() throws {
         while !stream.closed {
             do {
-                let data = try stream.read(upTo: self.bufferSize, deadline: timeout.fromNow())
+                let data = try stream.read(upTo: self.bufferSize, deadline: connectionTimeout.fromNow())
                 try processData(data)
             } catch StreamError.closedStream {
                 break

--- a/Sources/WebSocket/WebSocket.swift
+++ b/Sources/WebSocket/WebSocket.swift
@@ -51,10 +51,13 @@ public final class WebSocket {
     fileprivate let pingEventEmitter = EventEmitter<Buffer>()
     fileprivate let pongEventEmitter = EventEmitter<Buffer>()
     fileprivate let closeEventEmitter = EventEmitter<(code: CloseCode?, reason: String?)>()
+    
+    fileprivate let timeout: Double
 
-    public init(stream: Axis.Stream, mode: Mode) {
+    public init(stream: Axis.Stream, mode: Mode, timeout: Double = 60.seconds) {
         self.stream = stream
         self.mode = mode
+        self.timeout = timeout
     }
 
     @discardableResult
@@ -139,7 +142,7 @@ public final class WebSocket {
     public func start() throws {
         while !stream.closed {
             do {
-                let data = try stream.read(upTo: self.bufferSize, deadline: 5.seconds.fromNow())
+                let data = try stream.read(upTo: self.bufferSize, deadline: timeout.fromNow())
                 try processData(data)
             } catch StreamError.closedStream {
                 break


### PR DESCRIPTION
# problem

5.seconds.fromNow() is too short for slack webSockecet Client.
Usually many server is use 20 second ping/pong setting, so it should be
longer than that. Otherwise it throw SocketConnectionError

Slack send ping pong like 20 second interval, so for websockets, this
should be like 1.minute.fromNow().
# Fix

This PR made deadline (timeout second) to be parameter. Default timeout parameter is now `60.seconds`
# Result

I’ve tested and 5.seconds throw SocketConnectionError,
60.seconds.fromNow() can keep connection at least 2-3 hours
# Merge-ability

This adds connectionTimeout parameter on WebSocket Class but it has default value
so it should not make API conflict or changes. Should be safe to tag it.
