### PR TITLE
Fix problem generating size of extended payload in Frame when payload is more than 125 chars.

### DIFF
--- a/Sources/WebSocket/Buffer.swift
+++ b/Sources/WebSocket/Buffer.swift
@@ -26,9 +26,10 @@ extension Buffer {
             valuePointer.deallocate(capacity: 1)
         }
 
-        self = valuePointer.withMemoryRebound(to: UInt8.self, capacity: totalBytes) { bytes in
+        var bytes = [UInt8](repeating: 0, count: totalBytes)
+        self = valuePointer.withMemoryRebound(to: UInt8.self, capacity: totalBytes) { p in
             for i in 0..<totalBytes {
-                bytes[totalBytes - 1 - i] = (bytes + i).pointee
+                bytes[totalBytes - 1 - i] = (p + i).pointee
             }
             return Buffer(UnsafeBufferPointer(start: bytes, count: totalBytes))
         }


### PR DESCRIPTION
When the payload to a web socket frame is greater than 125, the extended payload length needs to be added in the Frame. currently, it mis-generates the size leading to the socket hanging on the receiver side (as it's expecting more data to come). This problem only happens from 0.13 -> 0.14.2 included.
