### PR TITLE
Close event as a struct

### DIFF
--- a/Sources/WebSocket/Close+Error.swift
+++ b/Sources/WebSocket/Close+Error.swift
@@ -1,0 +1,17 @@
+#if os(macOS)
+    
+    import Foundation
+    
+    extension Close : LocalizedError {
+        
+        public var errorDescription: String? {
+            return reason
+        }
+        
+    }
+    
+#else
+
+    extension Close : Error { }
+
+#endif

--- a/Sources/WebSocket/CloseCode.swift
+++ b/Sources/WebSocket/CloseCode.swift
@@ -70,3 +70,10 @@ public enum CloseCode : Equatable {
 public func == (lhs: CloseCode, rhs: CloseCode) -> Bool {
     return lhs.code == rhs.code
 }
+
+public struct Close {
+    
+    public var code: CloseCode?
+    public var reason: String?
+    
+}

--- a/Sources/WebSocket/WebSocket.swift
+++ b/Sources/WebSocket/WebSocket.swift
@@ -61,27 +61,27 @@ public final class WebSocket {
     }
 
     @discardableResult
-    public func onBinary(_ listen: @escaping EventListener<Buffer>.Listen) -> EventListener<Buffer> {
+    public func didReceiveBinary(_ listen: @escaping EventListener<Buffer>.Listen) -> EventListener<Buffer> {
         return binaryEventEmitter.addListener(listen: listen)
     }
 
     @discardableResult
-    public func onText(_ listen: @escaping EventListener<String>.Listen) -> EventListener<String> {
+    public func didReceiveText(_ listen: @escaping EventListener<String>.Listen) -> EventListener<String> {
         return textEventEmitter.addListener(listen: listen)
     }
 
     @discardableResult
-    public func onPing(_ listen: @escaping EventListener<Buffer>.Listen) -> EventListener<Buffer> {
+    public func didReceivePing(_ listen: @escaping EventListener<Buffer>.Listen) -> EventListener<Buffer> {
         return pingEventEmitter.addListener(listen: listen)
     }
 
     @discardableResult
-    public func onPong(_ listen: @escaping EventListener<Buffer>.Listen) -> EventListener<Buffer> {
+    public func didReceivePong(_ listen: @escaping EventListener<Buffer>.Listen) -> EventListener<Buffer> {
         return pongEventEmitter.addListener(listen: listen)
     }
 
     @discardableResult
-    public func onClose(_ listen: @escaping EventListener<(code: CloseCode?, reason: String?)>.Listen) -> EventListener<(code: CloseCode?, reason: String?)> {
+    public func didClose(_ listen: @escaping EventListener<(code: CloseCode?, reason: String?)>.Listen) -> EventListener<(code: CloseCode?, reason: String?)> {
         return closeEventEmitter.addListener(listen: listen)
     }
 


### PR DESCRIPTION
This pr introduces `WebSocket.Close`:

```swift
public struct Close {
    
    public var code: CloseCode?
    public var reason: String?
    
}
```

Which also is `Error` (`LocalizedError` on macOS and `Error` on Linux).
The reason for this is so that information about close can be passed as `Error`, which might be useful in a lot of cases